### PR TITLE
Add demo dataset downloader and minimal training config

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,5 +232,13 @@ Run an experiment by providing the experiment directory that contains the `confi
 ```
 python -m src.main "<path-to-experinment-directory>"
 ```
+We have provided the configurations for our baseline and extensions in `/experiments`. To run the experiments, you can download the dataset from [here](https://drive.google.com/drive/folders/1-dVRgcIsj6sN62v4OUGWgKTSODRIiP44). Store the data files in `data/datasets/64x32_33f_5y_5obs_uns`.
 
-We have provided the configurations for our baseline and extensions in `/experiments`. To run the experiments, you can download the dataset from [here](https://drive.google.com/drive/folders/1-dVRgcIsj6sN62v4OUGWgKTSODRIiP44). Store the data files in `data/datasets/64x32_33f_5y_5obs_uns`
+For a lightweight sanity check without downloading the full dataset you can generate a tiny subset from the public WeatherBench2 bucket:
+
+```
+python scripts/download_sample_data.py
+python -m src.main experiments/demo
+```
+
+The script downloads only a few days and three variables, so training finishes quickly and saves model weights in `experiments/demo/results/`.

--- a/experiments/demo/config.json
+++ b/experiments/demo/config.json
@@ -1,0 +1,55 @@
+{
+    "batch_size": 1,
+    "learning_rate": 1e-3,
+    "num_epochs": 2,
+    "wandb_log": false,
+    "random_seed": 42,
+    "graph": {
+        "grid2mesh_edge_creation": "radius",
+        "mesh2grid_edge_creation": "contained",
+        "grid2mesh_radius_query": 0.5,
+        "mesh_levels": [3]
+    },
+    "pipeline": {
+        "encoder": {
+            "mlp": {
+                "mlp_hidden_dims": [16],
+                "output_dim": 32,
+                "use_layer_norm": true,
+                "layer_norm_mode": "node"
+            },
+            "gcn": {
+                "layer_type": "conv_gcn",
+                "hidden_dims": [32],
+                "output_dim": 32
+            }
+        },
+        "processor": {
+            "gcn": {
+                "layer_type": "conv_gcn",
+                "hidden_dims": [32],
+                "output_dim": 32
+            }
+        },
+        "decoder": {
+            "mlp": {
+                "mlp_hidden_dims": [32],
+                "output_dim": 32,
+                "use_layer_norm": false
+            },
+            "gcn": {
+                "layer_type": "conv_gcn",
+                "hidden_dims": [16],
+                "output_dim": 3
+            }
+        }
+    },
+    "data": {
+        "dataset_name": "demo_era5_small",
+        "num_features_used": 3,
+        "obs_window_used": 2,
+        "pred_window_used": 1,
+        "want_feats_flattened": true
+    }
+}
+

--- a/scripts/download_sample_data.py
+++ b/scripts/download_sample_data.py
@@ -1,0 +1,98 @@
+"""Download a tiny ERA5 sample and store it in the format expected by the
+training pipeline.
+
+The script pulls a few days of data from the public WeatherBench2 bucket and
+creates train/test tensors.  Only three variables are used so that the data is
+small and the model can train quickly.
+"""
+
+from pathlib import Path
+import numpy as np
+import torch
+import xarray as xr
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+
+DATA_URL = (
+    "gs://weatherbench2/datasets/era5/"
+    "1959-2022-6h-64x32_equiangular_with_poles_conservative.zarr"
+)
+
+
+def _build_samples(arr: np.ndarray, obs: int, pred: int):
+    """Create lagged samples from an array of shape
+    (time, lon, lat, features)."""
+
+    X_list, y_list = [], []
+    total = arr.shape[0] - obs - pred + 1
+    for i in range(total):
+        X_list.append(arr[i : i + obs])
+        y_list.append(arr[i + obs : i + obs + pred])
+
+    X = np.stack(X_list)  # (samples, obs, lon, lat, feat)
+    y = np.stack(y_list)
+    return X, y
+
+
+def main():
+    out_dir = Path("data/datasets/demo_era5_small")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        ds = xr.open_zarr(
+            DATA_URL,
+            consolidated=True,
+            chunks={"time": 10},
+            storage_options={"token": "anon", "asynchronous": False},
+        )
+        ds = ds[
+            [
+                "10m_u_component_of_wind",
+                "10m_v_component_of_wind",
+                "2m_temperature",
+            ]
+        ]
+        ds = ds.sel(time=slice("2010-01-01", "2010-01-10"))
+        arr = ds.to_array().transpose("time", "longitude", "latitude", "variable").values
+    except Exception as e:  # pragma: no cover - network failures
+        print(f"Dataset download failed ({e}); using random data instead.")
+        arr = np.random.randn(10, 64, 32, 3)
+
+    obs_window, pred_window = 2, 1
+    X, y = _build_samples(arr, obs_window, pred_window)
+
+    samples, _, lon, lat, feat = X.shape
+    # reshape to (samples, lon, lat, obs_window*feat)
+    X = X.reshape(samples, obs_window, lon, lat, feat).transpose(0, 2, 3, 1, 4)
+    X = X.reshape(samples, lon, lat, obs_window * feat)
+    y = y.reshape(samples, pred_window, lon, lat, feat).transpose(0, 2, 3, 1, 4)
+    y = y.reshape(samples, lon, lat, pred_window * feat)
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+
+    scaler_x, scaler_y = StandardScaler(), StandardScaler()
+    X_train_flat = X_train.reshape(-1, obs_window * feat)
+    y_train_flat = y_train.reshape(-1, pred_window * feat)
+    X_train_scaled = scaler_x.fit_transform(X_train_flat).reshape(X_train.shape)
+    y_train_scaled = scaler_y.fit_transform(y_train_flat).reshape(y_train.shape)
+    X_test_scaled = scaler_x.transform(X_test.reshape(-1, obs_window * feat)).reshape(
+        X_test.shape
+    )
+    y_test_scaled = scaler_y.transform(y_test.reshape(-1, pred_window * feat)).reshape(
+        y_test.shape
+    )
+
+    torch.save(torch.tensor(X_train_scaled, dtype=torch.float32), out_dir / "X_train.pt")
+    torch.save(torch.tensor(y_train_scaled, dtype=torch.float32), out_dir / "y_train.pt")
+    torch.save(torch.tensor(X_test_scaled, dtype=torch.float32), out_dir / "X_test.pt")
+    torch.save(torch.tensor(y_test_scaled, dtype=torch.float32), out_dir / "y_test.pt")
+
+    print(f"Saved tensors to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/config.py
+++ b/src/config.py
@@ -41,6 +41,7 @@ class DatasetNames(str, Enum):
     _64x32_10f_5y_3obs = "64x32_10f_5y_3obs"
     _64x32_33f_5y_5obs_uns = "64x32_33f_5y_5obs_uns"
     _64x32_12f_2y_2obs_1pred_uns = "64x32_12f_2y_2obs_1pred_uns"
+    demo_era5_small = "demo_era5_small"
 
 
 class GraphBuildingConfig(BaseModel):

--- a/src/data/data_configs.py
+++ b/src/data/data_configs.py
@@ -47,5 +47,14 @@ def get_dataset_metadata(dataset_name: DatasetNames) -> DatasetMetadata:
             obs_window=2,
             pred_window=1,
         )
+    elif dataset_name == DatasetNames.demo_era5_small:
+        return DatasetMetadata(
+            flattened=True,
+            num_latitudes=32,
+            num_longitudes=64,
+            num_features=3,
+            obs_window=2,
+            pred_window=1,
+        )
     else:
         raise NotImplementedError(f"Dataset {dataset_name} is not supported.")

--- a/src/data/dataloader.py
+++ b/src/data/dataloader.py
@@ -2,8 +2,22 @@ import os
 from src.config import DataConfig
 from src.constants import FileNames
 import torch
-from data.data_loading import WeatherDataset
 from src.data.data_configs import DatasetMetadata, get_dataset_metadata
+from torch.utils.data import Dataset
+
+
+class WeatherDataset(Dataset):
+    """Simple tensor-based dataset used for training."""
+
+    def __init__(self, X, y):
+        self.X = X
+        self.y = y
+
+    def __len__(self):
+        return len(self.X)
+
+    def __getitem__(self, idx):
+        return self.X[idx], self.y[idx]
 
 
 def load_train_and_test_datasets(data_path: str, data_config: DataConfig):


### PR DESCRIPTION
## Summary
- add small demo experiment and dataset metadata entry
- provide script for downloading a tiny ERA5 sample (falls back to random data if download fails)
- document quickstart dataset generation and training

## Testing
- `python scripts/download_sample_data.py`
- `python -m src.main experiments/demo`


------
https://chatgpt.com/codex/tasks/task_e_688f7e117bd8832b8b27f0b947557797